### PR TITLE
Replace deprecated excludes_analyse with excludePaths

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -1,5 +1,5 @@
 parameters:
-    excludes_analyse:
+    excludePaths:
         - */app/code/local/*/*/data/*
         - */app/code/local/*/*/sql/*
     bootstrapFiles:


### PR DESCRIPTION
According to the phpstan documentation:
Parameter excludes_analyse has been deprecated so use excludePaths only from now on.