### PR TITLE
Handle case when getResourceModelClassName returns false

### DIFF
--- a/src/Type/Mage/GetResourceModel.php
+++ b/src/Type/Mage/GetResourceModel.php
@@ -7,7 +7,11 @@ final class GetResourceModel extends StaticMethodReturnTypeDetector
 {
     public function getMagentoClassName(string $identifier): string
     {
-        return $this->getMagentoConfig()->getResourceModelClassName($identifier);
+        $className = $this->getMagentoConfig()->getResourceModelClassName($identifier);
+        if ($className === false) {
+            throw new \PHPStan\Broker\ClassNotFoundException($identifier);
+        }
+        return $className;
     }
 
     protected static function getMethodName(): string


### PR DESCRIPTION
In case the magento identifier can't be translated into a class name, return meaningful error which mentions this identifier.
e.g.  
Class banner/banner_collection was not found while trying to analyse it - discovering symbols is probably not configured properly.

The same change should be done to other places where getResourceModelClassName is used